### PR TITLE
Fix MC-183776 inject method name

### DIFF
--- a/common/src/main/java/dev/isxander/debugify/mixins/basic/client/mc183776/KeyboardMixin.java
+++ b/common/src/main/java/dev/isxander/debugify/mixins/basic/client/mc183776/KeyboardMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @BugFix(id = "MC-183776", category = FixCategory.BASIC, env = BugFix.Env.CLIENT)
 @Mixin(Keyboard.class)
 public class KeyboardMixin {
-    @Inject(method = "processDebugKeys", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setScreen(Lnet/minecraft/client/gui/screen/Screen;)V", shift = At.Shift.AFTER), cancellable = true)
+    @Inject(method = "processF3", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setScreen(Lnet/minecraft/client/gui/screen/Screen;)V", shift = At.Shift.AFTER), cancellable = true)
     private void onSetGamemodeSelectionScreen(int key, CallbackInfoReturnable<Boolean> cir) {
         cir.setReturnValue(false);
     }


### PR DESCRIPTION
The previous method did not have a call to `setScreen`, so it would silently fail

Closes #105 