### PR TITLE
Action improvements

### DIFF
--- a/.github/workflows/check-bug-fixes.yml
+++ b/.github/workflows/check-bug-fixes.yml
@@ -18,6 +18,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - uses: actions/cache@v3
+        with:
+         path: ~/.cache/pip
+         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+         restore-keys: |
+          ${{ runner.os }}-pip-
       - name: Install pip requirements
         run: pip install requests
       - name: Run script

--- a/.github/workflows/check-bug-fixes.yml
+++ b/.github/workflows/check-bug-fixes.yml
@@ -18,12 +18,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - uses: actions/cache@v3
-        with:
-         path: ~/.cache/pip
-         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-         restore-keys: |
-          ${{ runner.os }}-pip-
       - name: Install pip requirements
         run: pip install requests
       - name: Run script

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,28 +25,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build with gradle
+    name: Build with Gradle
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2.3.1
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: temurin
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ./.gradle/loom-cache
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build --no-daemon
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build --no-daemon --stacktrace
       - uses: actions/upload-artifact@v3
         with:
           name: debugify-artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,23 +11,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2.3.1
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: temurin
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ./.gradle/loom-cache
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Publish to All Platforms
-        run: ./gradlew publishDebugify --no-daemon
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishDebugify --no-daemon
         env:
           xander-api.username: wyvest
           xander-api.password: ${{ secrets.XANDER_API_PASS }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build/
 run/
 !*/.gitkeep
+.vscode
+bin


### PR DESCRIPTION
Updates actions. This also switches over to `gradle/gradle-command-action` which provides a better caching system to `actions/setup-java` or `actions/cache`.

In addition - this adds a couple things to `.gitignore` for VS Code (just ignores `.vscode` entirely - you can revert this later if you want) and /bin/ directories - this showed up when it auto-builded in the /forge/ and /fabric/ directories, but only /forge/bin had anything inside of it.