### PR TITLE
Update zh_cn.json

### DIFF
--- a/src/main/resources/assets/debugify/lang/zh_cn.json
+++ b/src/main/resources/assets/debugify/lang/zh_cn.json
@@ -19,5 +19,5 @@
   "debugify.env.client": "客户端",
   "debugify.env.server": "服务器",
   "debugify.no_yacl.title": "YetAnotherConfigLib模组未安装！",
-  "debugify.no_yacl.description": "要使用GUI配置 Debugify，你必须安装 %s，这是用于实现该功能的前置。否则你可以使用JSON文件进行配置，它储存在‘%s’。"
+  "debugify.no_yacl.description": "要使用GUI配置Debugify，你必须安装 %s，这是用于实现该功能的前置。否则你可以使用JSON文件进行配置，它储存在‘%s’。"
 }

--- a/src/main/resources/assets/debugify/lang/zh_cn.json
+++ b/src/main/resources/assets/debugify/lang/zh_cn.json
@@ -2,12 +2,12 @@
   "debugify.name": "调试(Debugify)",
   "debugify.basic": "基本修复",
   "debugify.gameplay": "游戏修复",
-  "debugify.gameplay.warning": "警告: 此类别包含可能对其他人来说不公平的修复!",
+  "debugify.gameplay.warning": "警告：此类别包含可能对其他人来说不公平的修复！",
   "debugify.gameplay.enable_in_multiplayer": "在多人游戏中启用",
   "debugify.fix.enabled": "已修复",
   "debugify.fix.disabled": "未修复",
   "debugify.fix.unavailable": "不可用",
-  "debugify.error.conflict": "%s已经被模组'%s'修复",
+  "debugify.error.conflict": "%s已经被模组‘%s’修复",
   "debugify.error.os": "%s仅适用于%s",
   "debugify.os.windows": "Windows",
   "debugify.os.macos": "macOS",
@@ -15,8 +15,9 @@
   "debugify.os.solaris": "Solaris",
   "debugify.misc": "杂项",
   "debugify.misc.default_disabled": "默认为禁用",
-  "debugify.misc.default_disabled.description": "默认禁用新的错误修复,而不是启用.",
+  "debugify.misc.default_disabled.description": "默认禁用新的错误修复，而不是启用。",
   "debugify.env.client": "客户端",
   "debugify.env.server": "服务器",
-  "debugify.donate": "赞助我!"
+  "debugify.no_yacl.title": "YetAnotherConfigLib模组未安装！",
+  "debugify.no_yacl.description": "要使用GUI配置 Debugify，你必须安装 %s，这是用于实现该功能的前置。否则你可以使用JSON文件进行配置，它储存在‘%s’。"
 }


### PR DESCRIPTION
What's new:
1.Fix punctuation according to [General rules for punctuation](https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=22EA6D162E4110E752259661E1A0D0A8) /[ another url](https://people.ubuntu.com/~happyaron/l10n/GB(T)15834-2011.html) (national standards of People's Republic of China: GB/T 15834-2011) (If the symbols are in Chinese before and after, Full-width symbols will be used for unmentioned symbols because they appear to have the same width as Chinese) 2.Sync and translate with en_us.json