### PR TITLE
Update DebugifyApiTest.java to use corrected YACl name for 1.20.x

### DIFF
--- a/src/gametest/java/dev/isxander/debugify/test/DebugifyApiTest.java
+++ b/src/gametest/java/dev/isxander/debugify/test/DebugifyApiTest.java
@@ -13,6 +13,6 @@ public class DebugifyApiTest implements DebugifyApi {
 
     @Override
     public Map<String, Set<String>> getProvidedDisabledFixes() {
-        return Map.of("yet-another-config-lib", Set.of("MC-577"));
+        return Map.of("yet_another_config_lib_v3", Set.of("MC-577"));
     }
 }


### PR DESCRIPTION
Update DebugifyApiTest.java to use corrected YACl name for 1.20.x changed from "yet-another-config-lib" to "yet_another_config_lib_v3"