### PR TITLE
Fixes MC-176567

### DIFF
--- a/PATCHED.md
+++ b/PATCHED.md
@@ -25,7 +25,7 @@
 | Basic    | [MC-159163](https://bugs.mojang.com/browse/MC-159163) | Quickly pressing the sneak key causes the sneak animation to play twice                                                             |
 | Basic    | [MC-165381](https://bugs.mojang.com/browse/MC-165381) | Block breaking can be delayed by dropping/throwing the tool while breaking a block                                                  |                                                             |
 | Basic    | [MC-176559](https://bugs.mojang.com/browse/MC-176559) | Breaking process resets when a pickaxe enchanted with Mending mends by XP / Mending slows down breaking blocks again                |
-| Basic    | [MC-176567](https://bugs.mojang.com/browse/MC-176559) | Non in-game menus are locked at 60 fps                                                                                              |
+| Basic    | [MC-176567](https://bugs.mojang.com/browse/MC-176567) | Non in-game menus are locked at 60 fps                                                                                              |
 | Basic    | [MC-183776](https://bugs.mojang.com/browse/MC-183776) | After switching gamemodes using F3+F4, you need to press F3 twice to toggle the debug screen                                        |
 | Basic    | [MC-197260](https://bugs.mojang.com/browse/MC-197260) | Armor Stand renders itself and armor dark if its head is in a solid block                                                           |
 | Basic    | [MC-215531](https://bugs.mojang.com/browse/MC-215531) | The carved pumpkin overlay isn't removed when switching into spectator mode                                                         |

--- a/PATCHED.md
+++ b/PATCHED.md
@@ -25,6 +25,7 @@
 | Basic    | [MC-159163](https://bugs.mojang.com/browse/MC-159163) | Quickly pressing the sneak key causes the sneak animation to play twice                                                             |
 | Basic    | [MC-165381](https://bugs.mojang.com/browse/MC-165381) | Block breaking can be delayed by dropping/throwing the tool while breaking a block                                                  |                                                             |
 | Basic    | [MC-176559](https://bugs.mojang.com/browse/MC-176559) | Breaking process resets when a pickaxe enchanted with Mending mends by XP / Mending slows down breaking blocks again                |
+| Basic    | [MC-176567](https://bugs.mojang.com/browse/MC-176559) | Non in-game menus are locked at 60 fps                                                                                              |
 | Basic    | [MC-183776](https://bugs.mojang.com/browse/MC-183776) | After switching gamemodes using F3+F4, you need to press F3 twice to toggle the debug screen                                        |
 | Basic    | [MC-197260](https://bugs.mojang.com/browse/MC-197260) | Armor Stand renders itself and armor dark if its head is in a solid block                                                           |
 | Basic    | [MC-215531](https://bugs.mojang.com/browse/MC-215531) | The carved pumpkin overlay isn't removed when switching into spectator mode                                                         |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ## What does this mod replace?
 This mod replaces many mods and implements fixes from some others
 
+- **[SmoothMenu Refabricated](https://modrinth.com/mod/smoothmenu-refabricated)**
 - **[Shift-Scroll Fix](https://www.curseforge.com/minecraft/mc-mods/shift-scroll-fix)**
 - **[ForgetMeChunk](https://www.curseforge.com/minecraft/mc-mods/forgetmechunk)**
 - **[ChunkSavingFix](https://www.curseforge.com/minecraft/mc-mods/chunk-saving-fix)**

--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc176567/MinecraftMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc176567/MinecraftMixin.java
@@ -1,0 +1,27 @@
+package dev.isxander.debugify.client.mixins.basic.mc176567;
+
+import com.mojang.blaze3d.platform.Window;
+import dev.isxander.debugify.fixes.BugFix;
+import dev.isxander.debugify.fixes.FixCategory;
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@BugFix(id = "MC-176567", category = FixCategory.BASIC, env = BugFix.Env.CLIENT, modConflicts = "smoothmenu")
+@Mixin(Minecraft.class)
+public abstract class MinecraftMixin {
+    @Shadow
+    @Final
+    private Window window;
+
+    /**
+     * @author
+     * @reason
+     */
+    @Overwrite
+    private int getFramerateLimit() {
+        return window.getFramerateLimit();
+    }
+}

--- a/src/client/resources/debugify.client.mixins.json
+++ b/src/client/resources/debugify.client.mixins.json
@@ -20,6 +20,7 @@
     "basic.mc159163.ClientPacketListenerMixin",
     "basic.mc165381.LocalPlayerMixin",
     "basic.mc176559.MultiPlayerGameModeMixin",
+    "basic.mc176567.MinecraftMixin",
     "basic.mc183776.KeyboardHandlerMixin",
     "basic.mc197260.ArmorStandRendererMixin",
     "basic.mc197260.LivingEntityRendererMixin",


### PR DESCRIPTION
The mixin code is almost the same as the mixin code from https://github.com/shizotoaster/SmoothMenuRefabricated

Closes: #296 