### PR TITLE
fix instacrash bug

### DIFF
--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc577/AbstractContainerScreenMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc577/AbstractContainerScreenMixin.java
@@ -19,7 +19,8 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 @BugFix(id = "MC-577", category = FixCategory.BASIC, env = BugFix.Env.CLIENT)
 @Mixin(AbstractContainerScreen.class)
 public abstract class AbstractContainerScreenMixin extends Screen {
-    @Shadow protected abstract void slotClicked(Slot slot, int slotId, int button, ClickType actionType);
+    @Shadow
+    protected abstract void slotClicked(Slot slot, int slotId, int button, ClickType actionType);
 
     protected AbstractContainerScreenMixin(Component title) {
         super(title);
@@ -33,6 +34,7 @@ public abstract class AbstractContainerScreenMixin extends Screen {
     @Inject(method = "mouseClicked", at = @At(value = "INVOKE", target = "Lnet/minecraft/Util;getMillis()J"), locals = LocalCapture.CAPTURE_FAILSOFT, cancellable = true)
     private void dropWithMouse(double mouseX, double mouseY, int button, CallbackInfoReturnable<Boolean> cir, boolean isPickItem, Slot hoveredSlot) {
         if (minecraft.options.keyDrop.matchesMouse(button)) {
+            if (hoveredSlot == null) return;
             slotClicked(hoveredSlot, hoveredSlot.index, hasControlDown() ? 1 : 0, ClickType.THROW);
             cir.setReturnValue(true);
         }


### PR DESCRIPTION
yeah apparently if you click with the drop button on a NOT inventory slot, it'll just instantly crash your game

sorry if the code isn't exactly right, it's been years since i touched java and my vscode just straight up does not want to work with java

https://github.com/isXander/Debugify/assets/26746527/0c30f1fa-e9e6-4812-9545-f1e44dfd806c
![image](https://github.com/isXander/Debugify/assets/26746527/4670f0ba-b29c-440d-aaa8-7259faae40e7)


