### PR TITLE
MC-17738 Fix

### DIFF
--- a/PATCHED.md
+++ b/PATCHED.md
@@ -49,6 +49,7 @@
 | Basic    | [MC-89146](https://bugs.mojang.com/browse/MC-89146)   | Pistons forget update when being reloaded                                                                                                      |
 | Basic    | [MC-93018](https://bugs.mojang.com/browse/MC-93018)   | Wild wolves show breeding hearts but do not breed                                                                                              |
 | Basic    | [MC-100991](https://bugs.mojang.com/browse/MC-100991) | Killing entities with a fishing rod doesn't count as a kill                                                                                    |
+| Basic    | [MC-177381](https://bugs.mojang.com/browse/MC-177381) | Game does not count the distance properly if you locate a structure from more than 46340 blocks away                                           |
 | Basic    | [MC-119417](https://bugs.mojang.com/browse/MC-119417) | A spectator can occupy a bed if they enter it and then are switched to spectator mode                                                          |
 | Basic    | [MC-119754](https://bugs.mojang.com/browse/MC-119754) | Firework boosting on elytra continues in spectator mode                                                                                        |
 | Basic    | [MC-121706](https://bugs.mojang.com/browse/MC-121706) | Skeletons and illusioners aren't looking up / down at their target while strafing                                                              |

--- a/src/main/java/dev/isxander/debugify/mixins/basic/mc177831/LocateDistanceMixin.java
+++ b/src/main/java/dev/isxander/debugify/mixins/basic/mc177831/LocateDistanceMixin.java
@@ -1,0 +1,22 @@
+package dev.isxander.debugify.mixins.basic.mc177831;
+
+import dev.isxander.debugify.fixes.BugFix;
+import dev.isxander.debugify.fixes.FixCategory;
+import net.minecraft.server.commands.LocateCommand;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@BugFix(id = "MC-177831", category = FixCategory.BASIC, env = BugFix.Env.SERVER)
+@Mixin(LocateCommand.class)
+public class LocateDistanceMixin {
+    /**
+     * @author MaxenceDC
+     * @reason Fix MC-177831
+     */
+    @Overwrite
+    private static float dist(int pos1x, int pos1z, int pos2x, int pos2z) {
+        double delta_x = pos2x - pos1x;
+        double delta_y = pos2z - pos1z;
+        return (float) Math.hypot(delta_x, delta_y); // Math.hypot accounts for integer overflow, with error upto 1ulp
+    }
+}

--- a/src/main/resources/assets/debugify/lang/en_us.json
+++ b/src/main/resources/assets/debugify/lang/en_us.json
@@ -59,6 +59,7 @@
   "debugify.fix_explanation.mc-89146": "Provides a strict save order of tile entities, to match the update order which then allows initial update of tile entities to be in the correct order.",
   "debugify.fix_explanation.mc-93018": "Only initiate breeding if the wolf is tamed.",
   "debugify.fix_explanation.mc-100991": "Notifies the damage tracker of a thrown fishing hook damaging the entity with 0 damage, like snowballs.",
+  "debugify.fix_explanation.mc-177381": "The /locate command will now return the correct structure distance when very far from it.",
   "debugify.fix_explanation.mc-119417": "Stops player from sleeping when they change to spectator.",
   "debugify.fix_explanation.mc-119754": "Tells firework entities that players are not elytra flying if in spectator",
   "debugify.fix_explanation.mc-121706": "Entities with a ranged bow attack goal are forced to look at their target.",

--- a/src/main/resources/debugify.mixins.json
+++ b/src/main/resources/debugify.mixins.json
@@ -21,6 +21,7 @@
     "basic.mc14923.ServerGamePacketListenerImplMixin",
     "basic.mc155509.PufferfishMixin",
     "basic.mc160095.CactusBlockMixin",
+    "basic.mc177831.LocateDistanceMixin",
     "basic.mc179072.SwellGoalMixin",
     "basic.mc183990.MobMixin",
     "basic.mc193343.PlayerMixin",


### PR DESCRIPTION
https://bugs.mojang.com/browse/MC-177381 : Game does not count the distance properly if you locate a structure from more than 46340 blocks away

I fixed it using `Math.hypot` (I originally fixed this bug in my mod [Sparse Structures](https://github.com/MaxenceDC/sparsestructures), but thought it could fit in this mod too. This **does not** make the two mods incompatible, at least from my testing)