### PR TITLE
Fix MC-88371 crash

### DIFF
--- a/src/main/java/dev/isxander/debugify/mixins/basic/mc88371/DragonLandingPhaseMixin.java
+++ b/src/main/java/dev/isxander/debugify/mixins/basic/mc88371/DragonLandingPhaseMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 @BugFix(id = "MC-88371", category = FixCategory.BASIC, env = BugFix.Env.SERVER)
 @Mixin(DragonLandingPhase.class)
 public class DragonLandingPhaseMixin {
-    @ModifyExpressionValue(method = "doServerTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getHeightmapPos(Lnet/minecraft/world/level/levelgen/Heightmap$Types;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/BlockPos;"))
+    @ModifyExpressionValue(method = "doServerTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerLevel;getHeightmapPos(Lnet/minecraft/world/level/levelgen/Heightmap$Types;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/core/BlockPos;"))
     private BlockPos getLandingPos(BlockPos pos) {
         if (pos.getY() == 0) {
             // average height of portal


### PR DESCRIPTION
Starting from 1.21.2 (24w39a) `DragonLandingPhase#doServerTick` uses `ServerLevel`. Fixes #376


`DragonLandingPhase#doServerTick`

```diff
  @Override
- public void doServerTick() {
+ public void doServerTick(ServerLevel serverLevel) {
      if (this.targetLocation == null) {
          this.targetLocation = Vec3.atBottomCenterOf(
-             this.dragon.level().getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, EndPodiumFeature.getLocation(this.dragon.getFightOrigin()))
+             serverLevel.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, EndPodiumFeature.getLocation(this.dragon.getFightOrigin()))
          );
      }
    ...
  }
```