### PR TITLE
Move MC-159163 to a Gameplay fix

### DIFF
--- a/PATCHED.md
+++ b/PATCHED.md
@@ -20,7 +20,7 @@
 | Basic    | [MC-122477](https://bugs.mojang.com/browse/MC-122477) | Linux/GNU: Opening chat sometimes writes 't                                                                                         |
 | Basic    | [MC-127970](https://bugs.mojang.com/browse/MC-127970) | Using riptide on a trident with an item in your off-hand causes visual glitch with the item in your offhand                         |
 | Basic    | [MC-143474](https://bugs.mojang.com/browse/MC-143474) | Respawning causes your hotbar to reset to the first space                                                                           |
-| Basic    | [MC-159163](https://bugs.mojang.com/browse/MC-159163) | Quickly pressing the sneak key causes the sneak animation to play twice                                                             |
+| Gameplay | [MC-159163](https://bugs.mojang.com/browse/MC-159163) | Quickly pressing the sneak key causes the sneak animation to play twice                                                             |
 | Basic    | [MC-165381](https://bugs.mojang.com/browse/MC-165381) | Block breaking can be delayed by dropping/throwing the tool while breaking a block                                                  |                                                             |
 | Basic    | [MC-176559](https://bugs.mojang.com/browse/MC-176559) | Breaking process resets when a pickaxe enchanted with Mending mends by XP / Mending slows down breaking blocks again                |
 | Basic    | [MC-183776](https://bugs.mojang.com/browse/MC-183776) | After switching gamemodes using F3+F4, you need to press F3 twice to toggle the debug screen                                        |

--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc159163/ClientPacketListenerMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc159163/ClientPacketListenerMixin.java
@@ -19,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-@BugFix(id = "MC-159163", category = FixCategory.BASIC, env = BugFix.Env.CLIENT)
+@BugFix(id = "MC-159163", category = FixCategory.GAMEPLAY, env = BugFix.Env.CLIENT)
 @Mixin(ClientPacketListener.class)
 public abstract class ClientPacketListenerMixin extends ClientCommonPacketListenerImpl implements ClientGamePacketListener {
     protected ClientPacketListenerMixin(Minecraft client, Connection connection, CommonListenerCookie commonListenerCookie) {


### PR DESCRIPTION
Currently, this fix seems to consistently flag MinemenClub's (MMC) anticheat and cause a ban. As many 1.8 players are currently moving to 1.21+ due to MMC making a very faithful recreation of 1.8 combat in 1.21, many big communities are currently telling people to not use Debugify due to it banning players. Since Debugify already does fix some gameplay bugs that can flag anticheats but has a very clear warning for these features and requires manually enabling for servers, this fix should be moved there as well.

I have not investigated any other alternatives to fix this issue without flagging anticheats. lowercasebtw, the developer of Animatium, has also looked into this bug but couldn't find a fix that did not flag on MMC. As an immediate solution, I think it is better to just move this fix here.

I am also not familiar with the systems Debugify uses, I assume this should not cause any issue for users configs.