### PR TITLE
Resolve Moonrise mixin error

### DIFF
--- a/src/main/java/dev/isxander/debugify/mixins/basic/mc224729/ChunkMapMixin.java
+++ b/src/main/java/dev/isxander/debugify/mixins/basic/mc224729/ChunkMapMixin.java
@@ -13,7 +13,7 @@ import net.minecraft.server.level.ChunkMap;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ProtoChunk;
 
-@BugFix(id = "MC-224729", category = FixCategory.BASIC, env = BugFix.Env.SERVER, modConflicts = "chunksavingfix", description = "Partially generated chunks are not saved in some situations")
+@BugFix(id = "MC-224729", category = FixCategory.BASIC, env = BugFix.Env.SERVER, modConflicts = {"chunksavingfix", "moonrise"}, description = "Partially generated chunks are not saved in some situations")
 @Mixin(ChunkMap.class)
 public class ChunkMapMixin {
     @ModifyArg(method = "saveAllChunks", at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;filter(Ljava/util/function/Predicate;)Ljava/util/stream/Stream;", ordinal = 0))


### PR DESCRIPTION
This PR ensures that MC-224729's bug fix fails to load when Moonrise is installed. Moonrise overhauls the chunk system and resolves this bug, alongside various other chunk-related bugs that are not presently fixed in Debugify.