### PR TITLE
fix MC-271899

### DIFF
--- a/PATCHED.md
+++ b/PATCHED.md
@@ -62,6 +62,7 @@
 | Basic    | [MC-224729](https://bugs.mojang.com/browse/MC-224729) | Partially generated chunks are not saved in some situations                                                                                    |
 | Basic    | [MC-231743](https://bugs.mojang.com/browse/MC-231743) | minecraft.used:minecraft.POTTABLE_PLANT doesn't increase when placing plants into flower pots                                                  |
 | Basic    | [MC-232869](https://bugs.mojang.com/browse/MC-232869) | Adult striders can spawn with saddles in peaceful mode                                                                                         |
+| Basic    | [MC-271899](https://bugs.mojang.com/browse/MC-271899) | StructureTemplate Palette's caches are not thread safe                                                                                         |
 
 ## Previously patched
 Bugs that this mod has patched but has been superseded by a vanilla update.

--- a/src/main/java/dev/isxander/debugify/mixins/basic/mc271899/StructureTemplateMixin.java
+++ b/src/main/java/dev/isxander/debugify/mixins/basic/mc271899/StructureTemplateMixin.java
@@ -1,0 +1,31 @@
+package dev.isxander.debugify.mixins.basic.mc271899;
+
+import com.google.common.collect.Maps;
+import dev.isxander.debugify.fixes.BugFix;
+import dev.isxander.debugify.fixes.FixCategory;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+import java.util.Map;
+
+@BugFix(id = "MC-271899", category = FixCategory.BASIC, env = BugFix.Env.SERVER, description = "StructureTemplate Palette's caches are not thread safe")
+@Mixin(StructureTemplate.Palette.class)
+public class StructureTemplateMixin {
+    @Mutable
+    @Shadow
+    @Final
+    private Map<Block, List<StructureTemplate.StructureBlockInfo>> cache;
+
+    @Inject(method = "<init>", at = @At(value = "TAIL"))
+    private void newHashMap(List list, CallbackInfo ci) {
+        this.cache = Maps.newConcurrentMap();
+    }
+}

--- a/src/main/resources/debugify.mixins.json
+++ b/src/main/resources/debugify.mixins.json
@@ -30,6 +30,7 @@
     "basic.mc224729.ChunkMapMixin",
     "basic.mc231743.FlowerPotBlockMixin",
     "basic.mc232869.StriderMixin",
+    "basic.mc271899.StructureTemplateMixin",
     "basic.mc30391.LivingEntityMixin",
     "basic.mc69216.ServerPlayerMixin",
     "basic.mc7569.RconConsoleSourceMixin",


### PR DESCRIPTION
https://bugs.mojang.com/browse/MC/issues/MC-271899

this stems from a neoforge report. it seems its incredibly rare to reproduce but their patch (as described in the mojira bug report) should be enough to patch it. i'm pretty sure this is how you correctly implement a patch like this using mixin, but not 100% on it.

i was previously trying to wrapoperation/modifyexpression it and noticed i was nuking structures entirely. with this current mixin it appears that structures generate fine, so I'm PRing it