### PR TITLE
fix MC-242809

### DIFF
--- a/PATCHED.md
+++ b/PATCHED.md
@@ -28,6 +28,8 @@
 | Basic    | [MC-217716](https://bugs.mojang.com/browse/MC-217716) | The green nausea overlay isn't removed when switching into spectator mode                                                           |
 | Basic    | [MC-231097](https://bugs.mojang.com/browse/MC-231097) | Holding the "Use" button continues to slow down the player even after the used item has been dropped                                |
 | Basic    | [MC-237493](https://bugs.mojang.com/browse/MC-237493) | Telemetry cannot be disabled                                                                                                        |
+| Basic    | [MC-242809](https://bugs.mojang.com/browse/MC-242809) | IP field in the multiplayer menu will not detect the IP if a space is put at the beginning/end of it                                |
+
 
 ### Server Side (Both)
 | Type     | Bug ID                                                | Name                                                                                                                                           |

--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc242809/DirectJoinServerScreenMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc242809/DirectJoinServerScreenMixin.java
@@ -1,0 +1,24 @@
+package dev.isxander.debugify.client.mixins.basic.mc242809;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import dev.isxander.debugify.fixes.BugFix;
+import dev.isxander.debugify.fixes.FixCategory;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.DirectJoinServerScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@BugFix(id = "MC-242809", category = FixCategory.BASIC, env = BugFix.Env.CLIENT, description = "IP field in the multiplayer menu will not detect the IP if a space is put at the beginning/end of it")
+@Mixin(DirectJoinServerScreen.class)
+public class DirectJoinServerScreenMixin {
+    @WrapOperation(method = "onSelect", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/EditBox;getValue()Ljava/lang/String;"))
+    private String trimIpSelect(EditBox instance, Operation<String> original) {
+        return original.call(instance).trim();
+    }
+
+    @WrapOperation(method = "init", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/EditBox;setValue(Ljava/lang/String;)V"))
+    private void trimIpInit(EditBox instance, String string, Operation<Void> original) {
+        original.call(instance, string.trim());
+    }
+}

--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc242809/EditServerScreenMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc242809/EditServerScreenMixin.java
@@ -1,0 +1,19 @@
+package dev.isxander.debugify.client.mixins.basic.mc242809;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import dev.isxander.debugify.fixes.BugFix;
+import dev.isxander.debugify.fixes.FixCategory;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.EditServerScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@BugFix(id = "MC-242809", category = FixCategory.BASIC, env = BugFix.Env.CLIENT, description = "IP field in the multiplayer menu will not detect the IP if a space is put at the beginning/end of it")
+@Mixin(EditServerScreen.class)
+public class EditServerScreenMixin {
+    @WrapOperation(method = "onAdd", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/EditBox;getValue()Ljava/lang/String;", ordinal = 1))
+    private String trimIp(EditBox instance, Operation<String> original) {
+        return original.call(instance).trim();
+    }
+}

--- a/src/client/resources/debugify.client.mixins.json
+++ b/src/client/resources/debugify.client.mixins.json
@@ -29,6 +29,8 @@
     "basic.mc237493.TelemetryEventInstanceMixin",
     "basic.mc237493.TelemetryEventWidgetMixin",
     "basic.mc237493.TelemetryInfoScreenMixin",
+    "basic.mc242809.DirectJoinServerScreenMixin",
+    "basic.mc242809.EditServerScreenMixin",
     "basic.mc263865.KeyboardHandlerMixin",
     "basic.mc4490.FishingHookRendererMixin",
     "basic.mc46503.ClientPacketListenerMixin",


### PR DESCRIPTION
https://bugs.mojang.com/browse/MC/issues/MC-242809

it is worth noting that this bug is labeled as "Works as Intended", however I would argue this fix can still be incredibly useful for many people. I have seen many people trying to copy paste server IPs from other people and accidentally copying in a whitespace and getting confused on why they are unable to connect. IPs should never have spaces, so trimming them should be perfectly safe.

Additionally, debugify already fixes WAI bugs, notably the no telemetry fix.

I understand if you decide to close this but to me it seems a useful bugfix and quite uninvasive. Best case someone doesn't have to see an unhelpful error message for a typo, worst case no one notices this anyways.