### PR TITLE
fix crash when opening inventory

### DIFF
--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc35361/MinecraftMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc35361/MinecraftMixin.java
@@ -20,6 +20,6 @@ public class MinecraftMixin {
 
     @WrapWithCondition(method = "handleKeybinds", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/tutorial/Tutorial;onOpenInventory()V"))
     private boolean addNetherPortalCheck(Tutorial instance) {
-        return !this.player.portalProcess.isInsidePortalThisTick();
+        return this.player.portalProcess == null || !this.player.portalProcess.isInsidePortalThisTick();
     }
 }


### PR DESCRIPTION
I dont know how I didn't come across this in testing. I am 100% sure I tested opening my inventory to make sure it gave the advancement when I was not inside a portal, so I'm really confused as to why I didn't crash then..