### PR TITLE
fix MC-118740 & MC-116510

### DIFF
--- a/PATCHED.md
+++ b/PATCHED.md
@@ -19,6 +19,8 @@
 | Basic    | [MC-105068](https://bugs.mojang.com/browse/MC-105068) | Hitting another player blocking with a shield plays normal hurt sound                                                               |
 | Basic    | [MC-115092](https://bugs.mojang.com/browse/MC-115092) | Squid/glow squid named "Dinnerbone" or "Grumm" is not upside-down                                                                   |
 | Basic    | [MC-116379](https://bugs.mojang.com/browse/MC-116379) | Punching with a cast fishing rod in the off-hand detaches fishing line from rod                                                     |
+| Basic    | [MC-116510](https://bugs.mojang.com/browse/MC-116510) | Attack indicator doesn't indicate (most of the time) that breaking instantly-mineable blocks resets your attack                     |
+| Basic    | [MC-118740](https://bugs.mojang.com/browse/MC-118740) | Performing any right-click action silently resets the attack cooldown                                                               |
 | Basic    | [MC-122627](https://bugs.mojang.com/browse/MC-122627) | Tab suggestion box has missing padding on right side                                                                                |
 | Basic    | [MC-122477](https://bugs.mojang.com/browse/MC-122477) | Linux/GNU: Opening chat sometimes writes 't                                                                                         |
 | Basic    | [MC-127970](https://bugs.mojang.com/browse/MC-127970) | Using riptide on a trident with an item in your off-hand causes visual glitch with the item in your offhand                         |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,7 @@ tasks.processResources {
         FlashyReese's Sodium Extra - Code used licensed under LGPLv3
         Ampflower's 2x2 Surrounded Saplings Fix - Code used licensed under Zlib
         NoahvdAa's Thorium - Code used licensed under LGPLv3
+        Moulberry's MoulberryTweaks - Code used licensed under MIT
         """.trimIndent()
     inputs.property("version", project.version)
     inputs.property("description", modDescription)

--- a/src/client/java/dev/isxander/debugify/client/helpers/mc118740/LocalPlayerDuck.java
+++ b/src/client/java/dev/isxander/debugify/client/helpers/mc118740/LocalPlayerDuck.java
@@ -1,0 +1,14 @@
+package dev.isxander.debugify.client.helpers.mc118740;
+
+/**
+ * Taken from MoulberrysTweaks
+ * https://github.com/Moulberry/MoulberrysTweaks
+ * under MIT license
+ *
+ * @author Moulberry
+ */
+public interface LocalPlayerDuck {
+    float debugify$getVisualAttackStrengthScale(float partialTick);
+    void debugify$resetVisualAttackStrengthScale();
+    void debugify$incrementVisualAttackStrengthScale();
+}

--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc118740/GuiMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc118740/GuiMixin.java
@@ -1,0 +1,36 @@
+package dev.isxander.debugify.client.mixins.basic.mc118740;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import dev.isxander.debugify.client.helpers.mc118740.LocalPlayerDuck;
+import dev.isxander.debugify.fixes.BugFix;
+import dev.isxander.debugify.fixes.FixCategory;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.player.LocalPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * Taken from MoulberrysTweaks
+ * https://github.com/Moulberry/MoulberrysTweaks
+ * under MIT license
+ *
+ * @author Moulberry
+ */
+@BugFix(id = "MC-118740", category = FixCategory.BASIC, env = BugFix.Env.CLIENT, modConflicts = "moulberrystweaks", description = "Performing any right-click action silently resets the attack cooldown")
+@Mixin(Gui.class)
+public class GuiMixin {
+    /**
+     * This fixes both:
+     * MC-118740 - Performing any right-click action silently resets the attack cooldown
+     * MC-116510 - Attack indicator doesn't indicate (most of the time) that breaking instantly-mineable blocks resets your attack
+     */
+    @WrapOperation(method = "renderCrosshair", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getAttackStrengthScale(F)F"))
+    public float useFixedCooldown(LocalPlayer instance, float partialTick, Operation<Float> original) {
+        if (instance instanceof LocalPlayerDuck localPlayer) {
+            return localPlayer.debugify$getVisualAttackStrengthScale(partialTick);
+        } else {
+            return original.call(instance, partialTick);
+        }
+    }
+}

--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc118740/LocalPlayerMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc118740/LocalPlayerMixin.java
@@ -1,0 +1,54 @@
+package dev.isxander.debugify.client.mixins.basic.mc118740;
+
+import com.mojang.authlib.GameProfile;
+import dev.isxander.debugify.client.helpers.mc118740.LocalPlayerDuck;
+import dev.isxander.debugify.fixes.BugFix;
+import dev.isxander.debugify.fixes.FixCategory;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Taken from MoulberrysTweaks
+ * https://github.com/Moulberry/MoulberrysTweaks
+ * under MIT license
+ *
+ * @author Moulberry
+ */
+@BugFix(id = "MC-118740", category = FixCategory.BASIC, env = BugFix.Env.CLIENT, modConflicts = "moulberrystweaks", description = "Performing any right-click action silently resets the attack cooldown")
+@Mixin(LocalPlayer.class)
+public abstract class LocalPlayerMixin extends Player implements LocalPlayerDuck {
+    @Unique
+    private int visualAttackStrengthTicker = 0;
+
+    public LocalPlayerMixin(Level level, GameProfile gameProfile) {
+        super(level, gameProfile);
+    }
+
+    @Inject(method = "swing", at = @At("HEAD"))
+    public void swing(InteractionHand interactionHand, CallbackInfo ci) {
+        this.visualAttackStrengthTicker = 0;
+    }
+
+    @Override
+    public float debugify$getVisualAttackStrengthScale(float partialTick) {
+        return Mth.clamp(((float)this.visualAttackStrengthTicker + partialTick) / this.getCurrentItemAttackStrengthDelay(), 0.0F, 1.0F);
+    }
+
+    @Override
+    public void debugify$resetVisualAttackStrengthScale() {
+        this.visualAttackStrengthTicker = 0;
+    }
+
+    @Override
+    public void debugify$incrementVisualAttackStrengthScale() {
+        this.visualAttackStrengthTicker += 1;
+    }
+}

--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc118740/PlayerMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc118740/PlayerMixin.java
@@ -1,0 +1,35 @@
+package dev.isxander.debugify.client.mixins.basic.mc118740;
+
+import dev.isxander.debugify.client.helpers.mc118740.LocalPlayerDuck;
+import dev.isxander.debugify.fixes.BugFix;
+import dev.isxander.debugify.fixes.FixCategory;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Taken from MoulberrysTweaks
+ * https://github.com/Moulberry/MoulberrysTweaks
+ * under MIT license
+ *
+ * @author Moulberry
+ */
+@BugFix(id = "MC-118740", category = FixCategory.BASIC, env = BugFix.Env.CLIENT, modConflicts = "moulberrystweaks", description = "Performing any right-click action silently resets the attack cooldown")
+@Mixin(Player.class)
+public class PlayerMixin {
+    @Inject(method = "resetAttackStrengthTicker", at = @At("HEAD"))
+    public void resetAttackStrengthTicker(CallbackInfo ci) {
+        if (this instanceof LocalPlayerDuck localPlayerExt) {
+            localPlayerExt.debugify$resetVisualAttackStrengthScale();
+        }
+    }
+
+    @Inject(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;moveCloak()V"))
+    public void tick(CallbackInfo ci) {
+        if (this instanceof LocalPlayerDuck localPlayerExt) {
+            localPlayerExt.debugify$incrementVisualAttackStrengthScale();
+        }
+    }
+}

--- a/src/client/resources/debugify.client.mixins.json
+++ b/src/client/resources/debugify.client.mixins.json
@@ -21,8 +21,8 @@
     "basic.mc183776.KeyboardHandlerMixin",
     "basic.mc197260.ArmorStandRendererMixin",
     "basic.mc197260.LivingEntityRendererMixin",
-    "basic.mc210318.BookSignScreenMixin",
     "basic.mc201723.StatsScreenMixin",
+    "basic.mc210318.BookSignScreenMixin",
     "basic.mc211561.FishingHookRendererMixin",
     "basic.mc215531.GuiMixin",
     "basic.mc217716.GameRendererMixin",
@@ -35,10 +35,12 @@
     "basic.mc237493.TelemetryInfoScreenMixin",
     "basic.mc242809.DirectJoinServerScreenMixin",
     "basic.mc242809.EditServerScreenMixin",
+    "basic.mc118740.GuiMixin",
+    "basic.mc118740.LocalPlayerMixin",
     "basic.mc263865.KeyboardHandlerMixin",
-    "basic.mc35361.MinecraftMixin",
-    "basic.mc298558.AtmosphericFogEnvironmentMixin",
     "basic.mc268420.GuiMixin",
+    "basic.mc298558.AtmosphericFogEnvironmentMixin",
+    "basic.mc35361.MinecraftMixin",
     "basic.mc4490.FishingHookRendererMixin",
     "basic.mc46503.ClientPacketListenerMixin",
     "basic.mc46766.MinecraftMixin",
@@ -59,6 +61,7 @@
     "basic.mc188359.CakeBlockMixin",
     "basic.mc188359.ConsumableMixin",
     "basic.mc206540.EntityMixin",
+    "basic.mc118740.PlayerMixin",
     "basic.mc259512.LivingEntityMixin"
   ]
 }

--- a/src/main/resources/assets/debugify/lang/en_us.json
+++ b/src/main/resources/assets/debugify/lang/en_us.json
@@ -38,6 +38,8 @@
   "debugify.fix_explanation.mc-105068": "Make shield break sound a local sound.",
   "debugify.fix_explanation.mc-108948": "The issue is that the client does not run the same calculations as the server. When no one is controlling the boat, the client does not run physics on the boat, causing a client de-sync. This fix simply tells the client to run some physics calculations on the boat.",
   "debugify.fix_explanation.mc-111516": "Modifies a math acos calculation to make sure the result is not more than 1.0.",
+  "debugify.fix_explanation.mc-118740": "Displays the crosshair attack cooldown when performing a right click action.",
+  "debugify.fix_effect.mc-118740": "This also fixes MC-116510: Attack indicator doesn't indicate (most of the time) that breaking instantly-mineable blocks resets your attack",
   "debugify.fix_explanation.mc-112730": "Prevents beacons and other block entities from being added to the local block entity renderer list if they are already added to the global list.",
   "debugify.fix_explanation.mc-122477": "Prevents first two keyboard polls after an edit box is initialized, e.g. the chat box.",
   "debugify.fix_explanation.mc-123739": "Sorts recipe book entries by their identifier.",


### PR DESCRIPTION
This is taken from Moulberry's MoulberrysTweaks https://modrinth.com/mod/moulberrystweaks. His fix marks https://bugs.mojang.com/browse/MC/issues/MC-255058 as the fixed bug but I don't believe that to be right as it doesn't actually properly fix the core issue. I think fixing 255058 is better but I didn't do that because I know nothing about packets and I'm not sure if that would be fine with anticheats and stuff. This fix is quite important for PvP servers and I don't want it to be server side, and I figured at least showing the visible cooldown is better than nothing.