### PR TITLE
fix MC-197260 causing armorstands to render dark

### DIFF
--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc197260/ArmorStandRendererMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc197260/ArmorStandRendererMixin.java
@@ -1,6 +1,5 @@
 package dev.isxander.debugify.client.mixins.basic.mc197260;
 
-import com.mojang.datafixers.util.Pair;
 import dev.isxander.debugify.fixes.BugFix;
 import dev.isxander.debugify.fixes.FixCategory;
 import net.minecraft.client.Minecraft;
@@ -9,8 +8,6 @@ import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.state.ArmorStandRenderState;
 import org.spongepowered.asm.mixin.Mixin;
 
-import java.util.Comparator;
-import java.util.stream.IntStream;
 import net.minecraft.client.model.ArmorStandArmorModel;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.entity.ArmorStandRenderer;
@@ -39,13 +36,14 @@ public abstract class ArmorStandRendererMixin extends LivingEntityRendererMixin<
         BlockPos mainPos = BlockPos.containing(livingEntity.x, livingEntity.y, livingEntity.z);
         ClientLevel level = Minecraft.getInstance().level;
 
-        livingEntity.lightCoords = IntStream.of(-1, 0, 2, 3)
-                .mapToObj(operand -> {
-                    BlockPos pos = mainPos.offset(0, operand, 0);
-                    return Pair.of(level.getBrightness(LightLayer.BLOCK, pos), pos);
-                })
-                .max(Comparator.comparingInt(Pair::getFirst))
-                .map(p -> LightTexture.pack(p.getFirst(), level.getBrightness(LightLayer.SKY, p.getSecond())))
-                .orElse(livingEntity.lightCoords);
+        int maxSkyLight = 0;
+        int maxBlockLight = 0;
+        for (int offset : new int[] { -1, 0, 2, 3 }) {
+            BlockPos pos = mainPos.offset(0, offset, 0);
+            maxSkyLight = Math.max(maxSkyLight, level.getBrightness(LightLayer.SKY, pos));
+            maxBlockLight = Math.max(maxBlockLight, level.getBrightness(LightLayer.BLOCK, pos));
+        }
+
+        livingEntity.lightCoords = LightTexture.pack(maxBlockLight, maxSkyLight);
     }
 }


### PR DESCRIPTION
Fixes #507 

Root cause of this issue is that skylight is taken from the block with the highest block light.
If all block lights are 0, the sky light might be taken from a block where the sky light is 0 as well (e.g. the block below the armorstand).
Changed it to always merge all checked blocks: Using the highest sky light and highest block light.