### PR TITLE
fix MC-197260 causing armorstand preview within smithing table screen to render dark

### DIFF
--- a/src/client/java/dev/isxander/debugify/client/mixins/basic/mc197260/ArmorStandRendererMixin.java
+++ b/src/client/java/dev/isxander/debugify/client/mixins/basic/mc197260/ArmorStandRendererMixin.java
@@ -33,6 +33,8 @@ public abstract class ArmorStandRendererMixin extends LivingEntityRendererMixin<
      */
     @Override
     public void debugify$modifyLightCoords(ArmorStandRenderState livingEntity) {
+        if (LightTexture.sky(livingEntity.lightCoords) >= 15 || LightTexture.block(livingEntity.lightCoords) >= 15) return;
+
         BlockPos mainPos = BlockPos.containing(livingEntity.x, livingEntity.y, livingEntity.z);
         ClientLevel level = Minecraft.getInstance().level;
 


### PR DESCRIPTION
Fixes an issue with the fix for [MC-197260](https://mojira.dev/MC-197260) where the armor stand preview within the smithing table screen renders dark.
I could not find a nice way to distinguish between a normal armor stand and this preview, thats why I just skipped the lightCoords update if it's already set to full brightness.

I was not able to build it without changing some javadocs in https://github.com/isXander/Debugify/blob/1.21.10/src/main/java/dev/isxander/debugify/fixes/OS.java#L6 to ` {@link net.minecraft.util.Util.OS}`, have not included in the PR, as I don't know if it is just a me-issue.